### PR TITLE
Handle 500s from Routes in backend

### DIFF
--- a/src/main/scala/com/leagueprojecto/api/Routes.scala
+++ b/src/main/scala/com/leagueprojecto/api/Routes.scala
@@ -11,7 +11,7 @@ import akka.pattern.{CircuitBreaker, ask}
 import akka.util.Timeout
 import com.leagueprojecto.api.services.{MatchHistoryManager, SummonerManager}
 import com.leagueprojecto.api.services.SummonerManager.GetSummoner
-import com.leagueprojecto.api.services.riot.{ChampionService, RiotService, SummonerService}
+import com.leagueprojecto.api.services.riot.{ChampionService, RecentMatchesService, RiotService, SummonerService}
 import com.typesafe.config.Config
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import com.leagueprojecto.api.services.riot.ChampionService.GetChampions
@@ -43,6 +43,9 @@ trait Routes extends JsonProtocols {
     case e: RiotService.ServiceNotAvailable   => complete(HttpResponse(ServiceUnavailable))
     case e: RiotService.TooManyRequests       => complete(HttpResponse(TooManyRequests))
     case SummonerService.SummonerNotFound  => complete(HttpResponse(NotFound))
+    case RecentMatchesService.FailedRetrievingRecentMatches |
+         ChampionService.FailedRetrievingChampions |
+         SummonerService.FailedRetrievingSummoner => complete(HttpResponse(ServiceUnavailable))
     case _                                    => complete(HttpResponse(InternalServerError))
   }
 

--- a/src/main/scala/com/leagueprojecto/api/services/MatchHistoryManager.scala
+++ b/src/main/scala/com/leagueprojecto/api/services/MatchHistoryManager.scala
@@ -1,6 +1,7 @@
 package com.leagueprojecto.api.services
 
 import akka.actor.{ActorLogging, ActorRef, FSM, Props}
+import akka.actor.Status.Failure
 import akka.pattern.CircuitBreaker
 import com.leagueprojecto.api.domain.MatchDetail
 import com.leagueprojecto.api.domain.riot.RiotRecentMatches
@@ -48,14 +49,14 @@ class MatchHistoryManager(couchDbCircuitBreaker: CircuitBreaker) extends FSM[Sta
     case Event(RecentMatchesService.Result(matchIds), StateData(Some(RequestData(sender, _)), _)) if matchIds.isEmpty =>
       // In case there are no match ids, return an empty MatchHistory Seq back to the sender.
       sender ! Result(Seq.empty[MatchDetail])
-      log.debug("Returning matches from couchDB")
       stop()
     case Event(RecentMatchesService.Result(matchIds), state) =>
       // create the empty matchesMap which are to be filled by either the Db or Riot
       val matchesMap = matchIds.map(m => m -> None).toMap
       goto(RetrievingFromDb) using state.copy(matches = matchesMap)
-
-    // todo: handle riot errors
+    case Event(e @ RecentMatchesService.FailedRetrievingRecentMatches, StateData(Some(RequestData(sender, _)), _)) =>
+      sender ! Failure(e)
+      stop()
   }
 
   when(RetrievingFromDb) {
@@ -63,8 +64,8 @@ class MatchHistoryManager(couchDbCircuitBreaker: CircuitBreaker) extends FSM[Sta
       val mergedMatches = matches ++ matchDetails.map(m => m.matchId -> Some(m))
 
       if (!hasEmptyValues(mergedMatches)) {
-        sender ! Result(getValues(mergedMatches).sortBy(_.matchId))
         log.debug("Returning matches from RIOT")
+        sender ! Result(getValues(mergedMatches).sortBy(_.matchId))
         stop()
       } else {
         goto(RetrievingFromRiot) using StateData(Some(RequestData(sender, msg)), mergedMatches)
@@ -85,8 +86,6 @@ class MatchHistoryManager(couchDbCircuitBreaker: CircuitBreaker) extends FSM[Sta
       sender ! Result(mergedMatchesSeq.sortBy(_.matchId))
       log.debug("Returning merged matches from RIOT")
       goto(PersistingToDb) using StateData(Some(RequestData(sender, msg)), mergedMatches)
-
-    // todo: handle riot errors
   }
 
   when(PersistingToDb, stateTimeout = 10.seconds) {
@@ -127,8 +126,9 @@ class MatchHistoryManager(couchDbCircuitBreaker: CircuitBreaker) extends FSM[Sta
   }
 
   whenUnhandled {
-    case Event(msg, _) =>
+    case Event(msg, StateData(Some(RequestData(sender, _)), _)) =>
       log.error(s"Got unhandled message ($msg) in $stateName")
+      sender ! Failure(new IllegalStateException())
       stop()
   }
 

--- a/src/main/scala/com/leagueprojecto/api/services/SummonerManager.scala
+++ b/src/main/scala/com/leagueprojecto/api/services/SummonerManager.scala
@@ -52,8 +52,8 @@ class SummonerManager(couchDbCircuitBreaker: CircuitBreaker) extends FSM[State, 
     case Event(notFound @ SummonerService.SummonerNotFound, (Some(RequestData(sender, _)), _)) =>
       sender ! Failure(notFound)
       stop()
-    case Event(failure: Failure, (Some(RequestData(sender, _)), _)) =>
-      sender ! failure
+    case Event(riotError @ SummonerService.FailedRetrievingSummoner, (Some(RequestData(sender, _)), _)) =>
+      sender ! Failure(riotError)
       stop()
   }
 
@@ -94,6 +94,7 @@ class SummonerManager(couchDbCircuitBreaker: CircuitBreaker) extends FSM[State, 
   whenUnhandled {
     case Event(msg, _) =>
       log.error(s"Got unhandled message ($msg) in $stateName")
+      sender ! Failure(new IllegalStateException())
       stop()
   }
 

--- a/src/main/scala/com/leagueprojecto/api/services/riot/ChampionService.scala
+++ b/src/main/scala/com/leagueprojecto/api/services/riot/ChampionService.scala
@@ -1,5 +1,6 @@
 package com.leagueprojecto.api.services.riot
 
+import akka.actor.Status.Failure
 import akka.pattern.pipe
 import akka.actor.{ActorLogging, ActorRef, FSM, Props}
 import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
@@ -29,6 +30,8 @@ object ChampionService {
 
   case class ChampionsResponse(championList: ChampionList)
 
+  case object FailedRetrievingChampions extends Exception
+
   def props = Props[ChampionService]
 }
 
@@ -50,6 +53,7 @@ class ChampionService extends FSM[State, Data] with ActorLogging with RiotServic
       goto(RiotRequestFinished) using data
     case Event(x, RequestData(origSender)) =>
       log.error(s"Something went wrong retrieving champions: $x")
+      origSender ! Failure(FailedRetrievingChampions)
       stop()
   }
 


### PR DESCRIPTION
Error handling when a service returns an error, Before an actor calls the stop() method, always send a response to the original sender.